### PR TITLE
15.0 update

### DIFF
--- a/conf.d/main
+++ b/conf.d/main
@@ -15,19 +15,30 @@ service mysql start
 #Create mysql user and table
 mysql --user=root --password=$MYSQL_PASS --batch --execute "CREATE DATABASE $DB_NAME; GRANT SELECT,INSERT,UPDATE,DELETE,CREATE,DROP,ALTER ON $DB_NAME.* TO $DB_USER@localhost IDENTIFIED BY '$DB_PASS'; FLUSH PRIVILEGES;"
 
-#Set node version (6.9.0 confirmed to work); open to higher version
-n 6.9.0
+#Set node version (6.14.3 confirmed to work); open to higher version
+n 6.14.3
 
 mkdir $INSTALL_DIR
 
-npm i -g ghost-cli@1.5.2
+npm i -g ghost-cli
 
 sed -i '/function checkRootUser/a return 0;' $CHECK_USER
 sed -i '/const isRootInstall/a return 0;' $CHECK_USER
 
 cd $INSTALL_DIR
 
-ghost install --url=http://localhost:2368 --db=mysql --dbhost=localhost --dbuser=ghost --dbpass=$DB_PASS --dbname=ghost --no-prompt --mail=sendmail --no-stack || true
+#adding ghost user via install seems to cause issues
+adduser ghost --gecos ",,," --disabled-password
+echo "ghost:ghostpass" | chpasswd
+
+#sudo complains about hostname not being tkldev, this is a temporary fix
+sed -i 's/ghost/tkldev/' /etc/hosts
+
+ghost install --verbose --url=http://localhost:2368 --db=mysql --dbhost=localhost --dbuser=ghost --dbpass=$DB_PASS --dbname=ghost --no-prompt --mail=sendmail --no-stack || true
+
+sed -i 's/tkldev/ghost/' /etc/hosts
 
 #ghost runs on 2368. Proxy to port 80 and port 443 (SSL/TLS)
 ln -s /etc/nginx/sites-available/ghost /etc/nginx/sites-enabled/ghost
+
+service mysql stop

--- a/overlay/etc/init.d/ghost
+++ b/overlay/etc/init.d/ghost
@@ -1,0 +1,38 @@
+#!/bin/sh
+
+### BEGIN INIT INFO
+# Provides:         ghost
+# Required-Start:   $local_fs $network $named
+# Required-Stop:    $local_fs $network $named
+# Default-Start:    
+# Default-Stop:     
+# Short-Description: Starts Ghost in CHRoots
+# Description: Starts Ghost in CHRoots
+### END INIT INFO
+
+DESC="Ghost"
+NAME=ghost
+
+PIDFILE="/var/run/$NAME-initd.pid"
+DAEMON=/usr/local/bin/node
+
+USER="ghost"
+DIR="/opt/ghost"
+LOGFILE="/var/log/ghost.log"
+
+. /lib/lsb/init-functions
+
+case "$1" in
+    start)
+        start-stop-daemon --start --background --oknodo --user "$USER" \
+                --pidfile "$PIDFILE" --make-pidfile --chdir "$DIR" \
+                --startas "/bin/bash" -- \
+                -c "exec /usr/local/bin/node /usr/local/bin/ghost run > $LOGFILE"
+        ;;
+    stop)
+        start-stop-daemon --stop --background --oknodo --user "$USER" \
+                --pidfile "$PIDFILE"
+        ;;
+    *)
+        ;;
+esac

--- a/overlay/usr/local/bin/systemctl
+++ b/overlay/usr/local/bin/systemctl
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+command_name=$1
+service_name=$2
+
+if [[ $# == 1 ]]; then
+    if [[ $command_name == "daemon-reload" ]]; then
+        exit 0
+    fi
+elif [[ $# == 2 ]]; then
+    if [[ $command_name == "is-active" ]]; then
+        out=pgrep ghost
+        if [[ $! == 0 ]]; then
+            echo "active"
+            exit 0 
+        else
+            echo "inactive"
+            exit 1
+        fi
+    #elif [[ $command_name == "start" ]]; then
+    #    su ghost -s /bin/bash -c "NODE_ENV=production /usr/local/bin/node /usr/local/bin/ghost run --verbose"&
+    fi
+
+    if [[ $service_name == "ghost_localhost" ]]; then
+        service_name="ghost"
+    fi
+    service $service_name $command_name
+    exit $!
+fi

--- a/overlay/usr/local/bin/systemctl
+++ b/overlay/usr/local/bin/systemctl
@@ -5,6 +5,7 @@ service_name=$2
 
 if [[ $# == 1 ]]; then
     if [[ $command_name == "daemon-reload" ]]; then
+        # ignore daemon reloads, service command does not cache init.d scripts
         exit 0
     fi
 elif [[ $# == 2 ]]; then
@@ -17,8 +18,6 @@ elif [[ $# == 2 ]]; then
             echo "inactive"
             exit 1
         fi
-    #elif [[ $command_name == "start" ]]; then
-    #    su ghost -s /bin/bash -c "NODE_ENV=production /usr/local/bin/node /usr/local/bin/ghost run --verbose"&
     fi
 
     if [[ $service_name == "ghost_localhost" ]]; then

--- a/removelist
+++ b/removelist
@@ -1,0 +1,2 @@
+/usr/local/bin/systemctl
+/etc/init.d/ghost


### PR DESCRIPTION
GhostCLI now attempts to invoke systemctl which fails in a chroot. I have added a fake systemctl script which is in no way optimal to simulate the intended functionality of the systemctl commands GhostCLI uses. 

This however is not likely to be future proof as it only provides functionality which ghostcli was seen to use. 
This also includes an init.d script which serves as a way to start and stop ghost as a daemon while operating within a chroot, this suffers from the same future proofing issues as the systemctl script.